### PR TITLE
媒体库支持国内访问

### DIFF
--- a/src/containers/library-item.jsx
+++ b/src/containers/library-item.jsx
@@ -106,7 +106,7 @@ class LibraryItem extends React.PureComponent {
     render () {
         const iconMd5 = this.curIconMd5();
         const iconURL = iconMd5 ?
-            `https://cdn.assets.scratch.mit.edu/internalapi/asset/${iconMd5}/get/` :
+            `https://codingclip.com/fs/asset/${iconMd5}` :
             this.props.iconRawURL;
         return (
             <LibraryItemComponent

--- a/src/lib/libraries/costumes.json
+++ b/src/lib/libraries/costumes.json
@@ -1663,70 +1663,64 @@
         "rotationCenterY": 39
     },
     {
-        "name": "Cat Flying-a",
+        "assetId": "c6b1479621329fac5f2f8321678cc8d9",
+        "name": "Sparrow-smile",
         "tags": [
             "animals",
-            "cat",
-            "kitty",
-            "kitten"
+            "sparrow",
+            "funny",
+            "yellow"
         ],
-        "assetId": "a1ab94c8172c3b97ed9a2bf7c32172cd",
         "bitmapResolution": 1,
+        "md5ext": "c6b1479621329fac5f2f8321678cc8d9.svg",
         "dataFormat": "svg",
-        "md5ext": "a1ab94c8172c3b97ed9a2bf7c32172cd.svg",
-        "rotationCenterX": 55,
-        "rotationCenterY": 37
+        "rotationCenterX": 37.25555555555556,
+        "rotationCenterY": 46.0099173553719
     },
     {
-        "name": "Cat Flying-b",
+        "assetId": "ade067a9d36b483c33c3660fe4be5f39",
+        "name": "Sparrow-ww",
         "tags": [
             "animals",
-            "cat",
-            "kitty",
-            "kitten"
+            "sparrow",
+            "funny",
+            "yellow"
         ],
-        "assetId": "6667936a2793aade66c765c329379ad0",
         "bitmapResolution": 1,
+        "md5ext": "ade067a9d36b483c33c3660fe4be5f39.svg",
         "dataFormat": "svg",
-        "md5ext": "6667936a2793aade66c765c329379ad0.svg",
-        "rotationCenterX": 44,
-        "rotationCenterY": 46
+        "rotationCenterX": 37.25555111111109,
+        "rotationCenterY": 46.00991971074373
     },
     {
-        "name": "Cat-a",
+        "assetId": "bd3a66cf64c3b49faa05ca0533fefc7e",
+        "name": "Sparrow-unhappy",
         "tags": [
             "animals",
-            "cat",
-            "kitten",
-            "kitty",
-            "mammal",
-            "orange",
-            "scratch cat"
+            "sparrow",
+            "funny",
+            "yellow"
         ],
-        "assetId": "bcf454acf82e4504149f7ffe07081dbc",
         "bitmapResolution": 1,
+        "md5ext": "bd3a66cf64c3b49faa05ca0533fefc7e.svg",
         "dataFormat": "svg",
-        "md5ext": "bcf454acf82e4504149f7ffe07081dbc.svg",
-        "rotationCenterX": 48,
-        "rotationCenterY": 50
+        "rotationCenterX": 37.255552222222235,
+        "rotationCenterY": 46.00991942148735
     },
     {
-        "name": "Cat-b",
+        "assetId": "6ef589152edc575109df924e625cc434",
+        "name": "Sparrow-angry",
         "tags": [
             "animals",
-            "cat",
-            "kitten",
-            "kitty",
-            "mammal",
-            "orange",
-            "scratch cat"
+            "sparrow",
+            "funny",
+            "yellow"
         ],
-        "assetId": "0fb9be3e8397c983338cb71dc84d0b25",
         "bitmapResolution": 1,
+        "md5ext": "6ef589152edc575109df924e625cc434.svg",
         "dataFormat": "svg",
-        "md5ext": "0fb9be3e8397c983338cb71dc84d0b25.svg",
-        "rotationCenterX": 46,
-        "rotationCenterY": 53
+        "rotationCenterX": 37.25555666666665,
+        "rotationCenterY": 46.009922066115564
     },
     {
         "name": "Catcher-a",
@@ -4623,101 +4617,6 @@
         "rotationCenterY": 26
     },
     {
-        "name": "Giga Walk1",
-        "tags": [
-            "fantasy",
-            "walking"
-        ],
-        "assetId": "3afad833094d8dff1c4ff79edcaa13d0",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "3afad833094d8dff1c4ff79edcaa13d0.svg",
-        "rotationCenterX": 70,
-        "rotationCenterY": 107
-    },
-    {
-        "name": "Giga Walk2",
-        "tags": [
-            "fantasy",
-            "walking"
-        ],
-        "assetId": "d27716e022fb5f747d7b09fe6eeeca06",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "d27716e022fb5f747d7b09fe6eeeca06.svg",
-        "rotationCenterX": 71,
-        "rotationCenterY": 107
-    },
-    {
-        "name": "Giga Walk3",
-        "tags": [
-            "fantasy",
-            "walking"
-        ],
-        "assetId": "db55131bf54f96e8986d9b30730e42ce",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "db55131bf54f96e8986d9b30730e42ce.svg",
-        "rotationCenterX": 71,
-        "rotationCenterY": 107
-    },
-    {
-        "name": "Giga-a",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "happy"
-        ],
-        "assetId": "92161a11e851ecda94cbbb985018fed6",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "92161a11e851ecda94cbbb985018fed6.svg",
-        "rotationCenterX": 72,
-        "rotationCenterY": 96
-    },
-    {
-        "name": "Giga-b",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "happy"
-        ],
-        "assetId": "bc706a7648342aaacac9050378b40c43",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "bc706a7648342aaacac9050378b40c43.svg",
-        "rotationCenterX": 72,
-        "rotationCenterY": 96
-    },
-    {
-        "name": "Giga-c",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "happy"
-        ],
-        "assetId": "337b338b2b10176221e638ac537854e6",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "337b338b2b10176221e638ac537854e6.svg",
-        "rotationCenterX": 73,
-        "rotationCenterY": 96
-    },
-    {
-        "name": "Giga-d",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "mad"
-        ],
-        "assetId": "db15886cfdcb5e2f4459e9074e3990a1",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "db15886cfdcb5e2f4459e9074e3990a1.svg",
-        "rotationCenterX": 73,
-        "rotationCenterY": 96
-    },
-    {
         "name": "Giraffe-a",
         "tags": [
             "animals",
@@ -4970,51 +4869,6 @@
         "md5ext": "afb9fe328adae617ee3375366fca02e7.svg",
         "rotationCenterX": 40,
         "rotationCenterY": 80
-    },
-    {
-        "name": "Gobo-a",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "jenkins",
-            "ganglia"
-        ],
-        "assetId": "f505a4e9eab5e40e2669a4462dba4c90",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "f505a4e9eab5e40e2669a4462dba4c90.svg",
-        "rotationCenterX": 47,
-        "rotationCenterY": 55
-    },
-    {
-        "name": "Gobo-b",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "jenkins",
-            "ganglia"
-        ],
-        "assetId": "5c0896569305ab177d87caa31aad2a72",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "5c0896569305ab177d87caa31aad2a72.svg",
-        "rotationCenterX": 47,
-        "rotationCenterY": 55
-    },
-    {
-        "name": "Gobo-c",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "jenkins",
-            "ganglia"
-        ],
-        "assetId": "9d8021c216fb92cc708e1e96f3ed2b52",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "9d8021c216fb92cc708e1e96f3ed2b52.svg",
-        "rotationCenterX": 47,
-        "rotationCenterY": 55
     },
     {
         "name": "Grasshopper-a",
@@ -7421,61 +7275,6 @@
         "rotationCenterY": 48
     },
     {
-        "name": "Nano-a",
-        "tags": [
-            "fantasy",
-            "drawing"
-        ],
-        "assetId": "a62e560863c0e49b12e5d57e13d084f1",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "a62e560863c0e49b12e5d57e13d084f1.svg",
-        "rotationCenterX": 61,
-        "rotationCenterY": 60
-    },
-    {
-        "name": "Nano-b",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "happy"
-        ],
-        "assetId": "d12aead3e3c2917e7eba8b2b90a7afd2",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "d12aead3e3c2917e7eba8b2b90a7afd2.svg",
-        "rotationCenterX": 61,
-        "rotationCenterY": 60
-    },
-    {
-        "name": "Nano-c",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "happy"
-        ],
-        "assetId": "8f2f4a70e87262ef478ce60567b6208a",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "8f2f4a70e87262ef478ce60567b6208a.svg",
-        "rotationCenterX": 61,
-        "rotationCenterY": 60
-    },
-    {
-        "name": "Nano-d",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "angry"
-        ],
-        "assetId": "a4e2034751fa650fd5fd69432c110104",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "a4e2034751fa650fd5fd69432c110104.svg",
-        "rotationCenterX": 61,
-        "rotationCenterY": 60
-    },
-    {
         "name": "Neigh Pony",
         "tags": [
             "animals",
@@ -8070,113 +7869,6 @@
         "md5ext": "780467f3d173dcb37fd65834841babc6.svg",
         "rotationCenterX": 48,
         "rotationCenterY": 61
-    },
-    {
-        "name": "Pico Walk1",
-        "tags": [
-            "fantasy",
-            "walking"
-        ],
-        "assetId": "c8f58f31cabf4acabb3f828730061276",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "c8f58f31cabf4acabb3f828730061276.svg",
-        "rotationCenterX": 54,
-        "rotationCenterY": 71
-    },
-    {
-        "name": "Pico Walk2",
-        "tags": [
-            "fantasy",
-            "walking"
-        ],
-        "assetId": "52a60eccb624530fd3a24fc41fbad6e5",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "52a60eccb624530fd3a24fc41fbad6e5.svg",
-        "rotationCenterX": 54,
-        "rotationCenterY": 71
-    },
-    {
-        "name": "Pico Walk3",
-        "tags": [
-            "fantasy",
-            "walking"
-        ],
-        "assetId": "702bd644d01ea8eda2ea122daeea7d74",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "702bd644d01ea8eda2ea122daeea7d74.svg",
-        "rotationCenterX": 54,
-        "rotationCenterY": 70
-    },
-    {
-        "name": "Pico Walk4",
-        "tags": [
-            "fantasy",
-            "walking"
-        ],
-        "assetId": "22fb16ae7cc18187a7adaf2852f07884",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "22fb16ae7cc18187a7adaf2852f07884.svg",
-        "rotationCenterX": 54,
-        "rotationCenterY": 70
-    },
-    {
-        "name": "Pico-a",
-        "tags": [
-            "fantasy",
-            "drawing"
-        ],
-        "assetId": "e7ce31db37f7abd2901499db2e9ad83a",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "e7ce31db37f7abd2901499db2e9ad83a.svg",
-        "rotationCenterX": 55,
-        "rotationCenterY": 66
-    },
-    {
-        "name": "Pico-b",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "happy"
-        ],
-        "assetId": "a7597b1f0c13455d335a3d4fe77da528",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "a7597b1f0c13455d335a3d4fe77da528.svg",
-        "rotationCenterX": 55,
-        "rotationCenterY": 66
-    },
-    {
-        "name": "Pico-c",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "happy"
-        ],
-        "assetId": "bcc0e8a5dda3a813608902b887c87bb4",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "bcc0e8a5dda3a813608902b887c87bb4.svg",
-        "rotationCenterX": 55,
-        "rotationCenterY": 66
-    },
-    {
-        "name": "Pico-d",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "angry"
-        ],
-        "assetId": "d6dfa2efe58939af4c85755feb3c0375",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "d6dfa2efe58939af4c85755feb3c0375.svg",
-        "rotationCenterX": 55,
-        "rotationCenterY": 66
     },
     {
         "name": "Pitcher-a",
@@ -10257,61 +9949,6 @@
         "md5ext": "34fa36004be0340ec845ba6bbeb5e5d5.png",
         "rotationCenterX": 30,
         "rotationCenterY": 30
-    },
-    {
-        "name": "Tera-a",
-        "tags": [
-            "fantasy",
-            "drawing"
-        ],
-        "assetId": "18f9a11ecdbd3ad8719beb176c484d41",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "18f9a11ecdbd3ad8719beb176c484d41.svg",
-        "rotationCenterX": 49,
-        "rotationCenterY": 63
-    },
-    {
-        "name": "Tera-b",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "happy"
-        ],
-        "assetId": "365d4de6c99d71f1370f7c5e636728af",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "365d4de6c99d71f1370f7c5e636728af.svg",
-        "rotationCenterX": 49,
-        "rotationCenterY": 64
-    },
-    {
-        "name": "Tera-c",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "happy"
-        ],
-        "assetId": "2daca5f43efc2d29fb089879448142e9",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "2daca5f43efc2d29fb089879448142e9.svg",
-        "rotationCenterX": 49,
-        "rotationCenterY": 63
-    },
-    {
-        "name": "Tera-d",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "angry"
-        ],
-        "assetId": "5456a723f3b35eaa946b974a59888793",
-        "bitmapResolution": 1,
-        "dataFormat": "svg",
-        "md5ext": "5456a723f3b35eaa946b974a59888793.svg",
-        "rotationCenterX": 49,
-        "rotationCenterY": 63
     },
     {
         "name": "Toucan-a",

--- a/src/lib/libraries/sprites.json
+++ b/src/lib/libraries/sprites.json
@@ -2028,47 +2028,61 @@
         "blocks": {}
     },
     {
-        "name": "Cat",
+        "name": "Sparrow",
         "tags": [
             "animals",
-            "cat",
-            "kitten",
-            "kitty",
-            "mammal",
-            "orange",
-            "scratch cat"
+            "sparrow",
+            "funny",
+            "yellow"
         ],
         "isStage": false,
         "variables": {},
         "costumes": [
             {
-                "assetId": "bcf454acf82e4504149f7ffe07081dbc",
-                "name": "cat-a",
+                "assetId": "c6b1479621329fac5f2f8321678cc8d9",
+                "name": "smile",
                 "bitmapResolution": 1,
-                "md5ext": "bcf454acf82e4504149f7ffe07081dbc.svg",
+                "md5ext": "c6b1479621329fac5f2f8321678cc8d9.svg",
                 "dataFormat": "svg",
-                "rotationCenterX": 48,
-                "rotationCenterY": 50
+                "rotationCenterX": 37.25555555555556,
+                "rotationCenterY": 46.0099173553719
             },
             {
-                "assetId": "0fb9be3e8397c983338cb71dc84d0b25",
-                "name": "cat-b",
+                "assetId": "ade067a9d36b483c33c3660fe4be5f39",
+                "name": "ww",
                 "bitmapResolution": 1,
-                "md5ext": "0fb9be3e8397c983338cb71dc84d0b25.svg",
+                "md5ext": "ade067a9d36b483c33c3660fe4be5f39.svg",
                 "dataFormat": "svg",
-                "rotationCenterX": 46,
-                "rotationCenterY": 53
+                "rotationCenterX": 37.25555111111109,
+                "rotationCenterY": 46.00991971074373
+            },
+            {
+                "assetId": "bd3a66cf64c3b49faa05ca0533fefc7e",
+                "name": "unhappy",
+                "bitmapResolution": 1,
+                "md5ext": "bd3a66cf64c3b49faa05ca0533fefc7e.svg",
+                "dataFormat": "svg",
+                "rotationCenterX": 37.255552222222235,
+                "rotationCenterY": 46.00991942148735
+            },
+            {
+                "assetId": "6ef589152edc575109df924e625cc434",
+                "name": "angry",
+                "bitmapResolution": 1,
+                "md5ext": "6ef589152edc575109df924e625cc434.svg",
+                "dataFormat": "svg",
+                "rotationCenterX": 37.25555666666665,
+                "rotationCenterY": 46.009922066115564
             }
         ],
         "sounds": [
             {
-                "assetId": "83c36d806dc92327b9e7049a565c6bff",
-                "name": "Meow",
+                "assetId": "18e5a88512296cd96417449496bd8711",
+                "name": "Tropical Birds",
                 "dataFormat": "wav",
-                "format": "",
-                "rate": 44100,
-                "sampleCount": 37376,
-                "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+                "rate": 22050,
+                "sampleCount": 546609,
+                "md5ext": "18e5a88512296cd96417449496bd8711.wav"
             }
         ],
         "blocks": {}
@@ -2104,49 +2118,6 @@
                 "rate": 44100,
                 "sampleCount": 26048,
                 "md5ext": "cf51a0c4088942d95bcc20af13202710.wav"
-            }
-        ],
-        "blocks": {}
-    },
-    {
-        "name": "Cat Flying",
-        "tags": [
-            "animals",
-            "cat",
-            "kitty",
-            "kitten"
-        ],
-        "isStage": false,
-        "variables": {},
-        "costumes": [
-            {
-                "assetId": "a1ab94c8172c3b97ed9a2bf7c32172cd",
-                "name": "cat flying-a",
-                "bitmapResolution": 1,
-                "md5ext": "a1ab94c8172c3b97ed9a2bf7c32172cd.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 55,
-                "rotationCenterY": 37
-            },
-            {
-                "assetId": "6667936a2793aade66c765c329379ad0",
-                "name": "cat flying-b",
-                "bitmapResolution": 1,
-                "md5ext": "6667936a2793aade66c765c329379ad0.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 44,
-                "rotationCenterY": 46
-            }
-        ],
-        "sounds": [
-            {
-                "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
-                "name": "Pop",
-                "dataFormat": "wav",
-                "format": "",
-                "rate": 44100,
-                "sampleCount": 1032,
-                "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
             }
         ],
         "blocks": {}
@@ -5703,115 +5674,6 @@
         "blocks": {}
     },
     {
-        "name": "Giga",
-        "tags": [
-            "fantasy",
-            "drawing"
-        ],
-        "isStage": false,
-        "variables": {},
-        "costumes": [
-            {
-                "assetId": "92161a11e851ecda94cbbb985018fed6",
-                "name": "giga-a",
-                "bitmapResolution": 1,
-                "md5ext": "92161a11e851ecda94cbbb985018fed6.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 72,
-                "rotationCenterY": 96
-            },
-            {
-                "assetId": "bc706a7648342aaacac9050378b40c43",
-                "name": "giga-b",
-                "bitmapResolution": 1,
-                "md5ext": "bc706a7648342aaacac9050378b40c43.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 72,
-                "rotationCenterY": 96
-            },
-            {
-                "assetId": "337b338b2b10176221e638ac537854e6",
-                "name": "giga-c",
-                "bitmapResolution": 1,
-                "md5ext": "337b338b2b10176221e638ac537854e6.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 73,
-                "rotationCenterY": 96
-            },
-            {
-                "assetId": "db15886cfdcb5e2f4459e9074e3990a1",
-                "name": "giga-d",
-                "bitmapResolution": 1,
-                "md5ext": "db15886cfdcb5e2f4459e9074e3990a1.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 73,
-                "rotationCenterY": 96
-            }
-        ],
-        "sounds": [
-            {
-                "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
-                "name": "pop",
-                "dataFormat": "wav",
-                "format": "",
-                "rate": 44100,
-                "sampleCount": 1032,
-                "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
-            }
-        ],
-        "blocks": {}
-    },
-    {
-        "name": "Giga Walking",
-        "tags": [
-            "fantasy",
-            "walking"
-        ],
-        "isStage": false,
-        "variables": {},
-        "costumes": [
-            {
-                "assetId": "3afad833094d8dff1c4ff79edcaa13d0",
-                "name": "Giga walk1",
-                "bitmapResolution": 1,
-                "md5ext": "3afad833094d8dff1c4ff79edcaa13d0.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 70,
-                "rotationCenterY": 107
-            },
-            {
-                "assetId": "d27716e022fb5f747d7b09fe6eeeca06",
-                "name": "Giga walk2",
-                "bitmapResolution": 1,
-                "md5ext": "d27716e022fb5f747d7b09fe6eeeca06.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 71,
-                "rotationCenterY": 107
-            },
-            {
-                "assetId": "db55131bf54f96e8986d9b30730e42ce",
-                "name": "Giga walk3",
-                "bitmapResolution": 1,
-                "md5ext": "db55131bf54f96e8986d9b30730e42ce.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 71,
-                "rotationCenterY": 107
-            }
-        ],
-        "sounds": [
-            {
-                "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
-                "name": "pop",
-                "dataFormat": "wav",
-                "format": "",
-                "rate": 44100,
-                "sampleCount": 1032,
-                "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
-            }
-        ],
-        "blocks": {}
-    },
-    {
         "name": "Giraffe",
         "tags": [
             "animals",
@@ -6090,58 +5952,6 @@
                 "rate": 44100,
                 "sampleCount": 22494,
                 "md5ext": "b92de59d992a655c1b542223a784cda6.wav"
-            }
-        ],
-        "blocks": {}
-    },
-    {
-        "name": "Gobo",
-        "tags": [
-            "fantasy",
-            "drawing",
-            "jenkins",
-            "ganglia"
-        ],
-        "isStage": false,
-        "variables": {},
-        "costumes": [
-            {
-                "assetId": "f505a4e9eab5e40e2669a4462dba4c90",
-                "name": "gobo-a",
-                "bitmapResolution": 1,
-                "md5ext": "f505a4e9eab5e40e2669a4462dba4c90.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 47,
-                "rotationCenterY": 55
-            },
-            {
-                "assetId": "5c0896569305ab177d87caa31aad2a72",
-                "name": "gobo-b",
-                "bitmapResolution": 1,
-                "md5ext": "5c0896569305ab177d87caa31aad2a72.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 47,
-                "rotationCenterY": 55
-            },
-            {
-                "assetId": "9d8021c216fb92cc708e1e96f3ed2b52",
-                "name": "gobo-c",
-                "bitmapResolution": 1,
-                "md5ext": "9d8021c216fb92cc708e1e96f3ed2b52.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 47,
-                "rotationCenterY": 55
-            }
-        ],
-        "sounds": [
-            {
-                "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
-                "name": "pop",
-                "dataFormat": "wav",
-                "format": "",
-                "rate": 44100,
-                "sampleCount": 1032,
-                "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
             }
         ],
         "blocks": {}
@@ -9295,65 +9105,6 @@
         "blocks": {}
     },
     {
-        "name": "Nano",
-        "tags": [
-            "fantasy",
-            "drawing"
-        ],
-        "isStage": false,
-        "variables": {},
-        "costumes": [
-            {
-                "assetId": "a62e560863c0e49b12e5d57e13d084f1",
-                "name": "nano-a",
-                "bitmapResolution": 1,
-                "md5ext": "a62e560863c0e49b12e5d57e13d084f1.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 61,
-                "rotationCenterY": 60
-            },
-            {
-                "assetId": "d12aead3e3c2917e7eba8b2b90a7afd2",
-                "name": "nano-b",
-                "bitmapResolution": 1,
-                "md5ext": "d12aead3e3c2917e7eba8b2b90a7afd2.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 61,
-                "rotationCenterY": 60
-            },
-            {
-                "assetId": "8f2f4a70e87262ef478ce60567b6208a",
-                "name": "nano-c",
-                "bitmapResolution": 1,
-                "md5ext": "8f2f4a70e87262ef478ce60567b6208a.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 61,
-                "rotationCenterY": 60
-            },
-            {
-                "assetId": "a4e2034751fa650fd5fd69432c110104",
-                "name": "nano-d",
-                "bitmapResolution": 1,
-                "md5ext": "a4e2034751fa650fd5fd69432c110104.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 61,
-                "rotationCenterY": 60
-            }
-        ],
-        "sounds": [
-            {
-                "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
-                "name": "pop",
-                "dataFormat": "wav",
-                "format": "",
-                "rate": 44100,
-                "sampleCount": 1032,
-                "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
-            }
-        ],
-        "blocks": {}
-    },
-    {
         "name": "Neigh Pony",
         "tags": [
             "animals",
@@ -10083,124 +9834,6 @@
                 "rate": 22050,
                 "sampleCount": 6097,
                 "md5ext": "3b8236bbb288019d93ae38362e865972.wav"
-            }
-        ],
-        "blocks": {}
-    },
-    {
-        "name": "Pico",
-        "tags": [
-            "fantasy",
-            "drawing"
-        ],
-        "isStage": false,
-        "variables": {},
-        "costumes": [
-            {
-                "assetId": "e7ce31db37f7abd2901499db2e9ad83a",
-                "name": "pico-a",
-                "bitmapResolution": 1,
-                "md5ext": "e7ce31db37f7abd2901499db2e9ad83a.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 55,
-                "rotationCenterY": 66
-            },
-            {
-                "assetId": "a7597b1f0c13455d335a3d4fe77da528",
-                "name": "pico-b",
-                "bitmapResolution": 1,
-                "md5ext": "a7597b1f0c13455d335a3d4fe77da528.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 55,
-                "rotationCenterY": 66
-            },
-            {
-                "assetId": "bcc0e8a5dda3a813608902b887c87bb4",
-                "name": "pico-c",
-                "bitmapResolution": 1,
-                "md5ext": "bcc0e8a5dda3a813608902b887c87bb4.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 55,
-                "rotationCenterY": 66
-            },
-            {
-                "assetId": "d6dfa2efe58939af4c85755feb3c0375",
-                "name": "pico-d",
-                "bitmapResolution": 1,
-                "md5ext": "d6dfa2efe58939af4c85755feb3c0375.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 55,
-                "rotationCenterY": 66
-            }
-        ],
-        "sounds": [
-            {
-                "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
-                "name": "pop",
-                "dataFormat": "wav",
-                "format": "",
-                "rate": 44100,
-                "sampleCount": 1032,
-                "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
-            }
-        ],
-        "blocks": {}
-    },
-    {
-        "name": "Pico Walking",
-        "tags": [
-            "fantasy",
-            "walking"
-        ],
-        "isStage": false,
-        "variables": {},
-        "costumes": [
-            {
-                "assetId": "c8f58f31cabf4acabb3f828730061276",
-                "name": "Pico walk1",
-                "bitmapResolution": 1,
-                "md5ext": "c8f58f31cabf4acabb3f828730061276.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 54,
-                "rotationCenterY": 71
-            },
-            {
-                "assetId": "52a60eccb624530fd3a24fc41fbad6e5",
-                "name": "Pico walk2",
-                "bitmapResolution": 1,
-                "md5ext": "52a60eccb624530fd3a24fc41fbad6e5.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 54,
-                "rotationCenterY": 71
-            },
-            {
-                "assetId": "702bd644d01ea8eda2ea122daeea7d74",
-                "name": "Pico walk3",
-                "bitmapResolution": 1,
-                "md5ext": "702bd644d01ea8eda2ea122daeea7d74.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 54,
-                "rotationCenterY": 70
-            },
-            {
-                "assetId": "22fb16ae7cc18187a7adaf2852f07884",
-                "name": "Pico walk4",
-                "bitmapResolution": 1,
-                "md5ext": "22fb16ae7cc18187a7adaf2852f07884.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 54,
-                "rotationCenterY": 70
-            }
-        ],
-        "sounds": [
-            {
-                "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
-                "name": "pop",
-                "dataFormat": "wav",
-                "format": "",
-                "rate": 44100,
-                "sampleCount": 1032,
-                "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
             }
         ],
         "blocks": {}
@@ -12884,65 +12517,6 @@
                 "dataFormat": "png",
                 "rotationCenterX": 30,
                 "rotationCenterY": 30
-            }
-        ],
-        "sounds": [
-            {
-                "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
-                "name": "pop",
-                "dataFormat": "wav",
-                "format": "",
-                "rate": 44100,
-                "sampleCount": 1032,
-                "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
-            }
-        ],
-        "blocks": {}
-    },
-    {
-        "name": "Tera",
-        "tags": [
-            "fantasy",
-            "drawing"
-        ],
-        "isStage": false,
-        "variables": {},
-        "costumes": [
-            {
-                "assetId": "18f9a11ecdbd3ad8719beb176c484d41",
-                "name": "tera-a",
-                "bitmapResolution": 1,
-                "md5ext": "18f9a11ecdbd3ad8719beb176c484d41.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 49,
-                "rotationCenterY": 63
-            },
-            {
-                "assetId": "365d4de6c99d71f1370f7c5e636728af",
-                "name": "tera-b",
-                "bitmapResolution": 1,
-                "md5ext": "365d4de6c99d71f1370f7c5e636728af.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 49,
-                "rotationCenterY": 64
-            },
-            {
-                "assetId": "2daca5f43efc2d29fb089879448142e9",
-                "name": "tera-c",
-                "bitmapResolution": 1,
-                "md5ext": "2daca5f43efc2d29fb089879448142e9.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 49,
-                "rotationCenterY": 63
-            },
-            {
-                "assetId": "5456a723f3b35eaa946b974a59888793",
-                "name": "tera-d",
-                "bitmapResolution": 1,
-                "md5ext": "5456a723f3b35eaa946b974a59888793.svg",
-                "dataFormat": "svg",
-                "rotationCenterX": 49,
-                "rotationCenterY": 63
             }
         ],
         "sounds": [

--- a/src/lib/project-fetcher-hoc.jsx
+++ b/src/lib/project-fetcher-hoc.jsx
@@ -130,7 +130,7 @@ const ProjectFetcherHOC = function (WrappedComponent) {
         setProjectId: PropTypes.func
     };
     ProjectFetcherComponent.defaultProps = {
-        assetHost: 'https://assets.scratch.mit.edu',
+        assetHost: 'https://codingclip.com/fs',
         projectHost: 'https://projects.scratch.mit.edu'
     };
 

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -54,7 +54,7 @@ class Storage extends ScratchStorage {
         this.assetHost = assetHost;
     }
     getAssetGetConfig (asset) {
-        return `${this.assetHost}/internalapi/asset/${asset.assetId}.${asset.dataFormat}/get/`;
+        return `${this.assetHost}/asset/${asset.assetId}.${asset.dataFormat}`;
     }
     getAssetCreateConfig (asset) {
         return {


### PR DESCRIPTION
# 介绍
本分支将Scratch内置的媒体库修改为CC社区的媒体库，以此解决国内不可用问题  
![image](https://user-images.githubusercontent.com/46376077/139293168-1abf0d51-7b37-47a7-85a7-cd89552fe5e2.png)

# 目前仍然存在的问题  

- [ ] svg图片无法显示（fs问题）
- [ ] CC社区部分资源不存在/未上传
- [ ] 音频可能无法播放（cors问题）