### PR TITLE
文件系统api及自动保存

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,7 @@
             "messagesDir": "./translations/messages/"
         }]],
     "presets": [
-        ["@babel/preset-env", {"targets": {"browsers": ["last 3 versions", "Safari >= 8", "iOS >= 8"]}}],
+        ["@babel/preset-env"],
         "@babel/preset-react"
     ]
 }

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,4 @@
-last 3 versions
-Safari >= 8
-iOS >= 8
+Safari >= 12
+iOS >= 12
+chrome >= 72
+firefox >= 70

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -515,7 +515,7 @@ class MenuBar extends React.Component {
                                         </MenuItem>
                                         <SB3Downloader>{(className, downloadProjectCallback, saveToLastFile) => (
                                             <React.Fragment>
-                                                {window.showSaveFilePicker && this.props.isStandalone && (
+                                                {window.showSaveFilePicker && (
                                                     <MenuItem
                                                         className={classNames(className, {
                                                             [styles.disabled]: this.props.fileHandle === null

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -515,7 +515,7 @@ class MenuBar extends React.Component {
                                         </MenuItem>
                                         <SB3Downloader>{(className, downloadProjectCallback, saveToLastFile) => (
                                             <React.Fragment>
-                                                {window.showSaveFilePicker && (
+                                                {window.showSaveFilePicker && this.props.isStandalone && (
                                                     <MenuItem
                                                         className={classNames(className, {
                                                             [styles.disabled]: this.props.fileHandle === null
@@ -733,7 +733,11 @@ class MenuBar extends React.Component {
                 {/* show the proper UI in the account menu, given whether the user is
                 logged in, and whether a session is available to log in with */}
                 <div className={styles.menuBarItem}>
-                    <SaveStatus canSave={this.props.canSave} />
+                    <SaveStatus
+                        canSave={this.props.canSave}
+                        isStandalone={this.props.isStandalone}
+                        fileHandle={this.props.fileHandle}
+                    />
                 </div>
                 {this.props.isStandalone ? null : (
                     <div className={styles.accountInfoGroup}>

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -43,7 +43,8 @@ import {
     manualUpdateProject,
     requestNewProject,
     remixProject,
-    saveProjectAsCopy
+    saveProjectAsCopy,
+    setFileSystemHandle
 } from '../../reducers/project-state';
 import {
     openAboutMenu,
@@ -201,6 +202,7 @@ class MenuBar extends React.Component {
         const readyToReplaceProject = this.props.confirmReadyToReplaceProject(
             this.props.intl.formatMessage(sharedMessages.replaceProjectWarning)
         );
+        this.props.onSetFileSystemHandle(null);
         this.props.onRequestCloseFile();
         if (readyToReplaceProject) {
             this.props.onClickNew(this.props.canSave && this.props.canCreateNew);
@@ -249,7 +251,7 @@ class MenuBar extends React.Component {
         this.props.onRequestCloseOther();
     }
 
-    handleClickContributor() {
+    handleClickContributor () {
         this.props.onOpenContributor();
         this.props.onRequestCloseOther();
     }
@@ -511,17 +513,33 @@ class MenuBar extends React.Component {
                                         >
                                             {this.props.intl.formatMessage(sharedMessages.loadFromComputerTitle)}
                                         </MenuItem>
-                                        <SB3Downloader>{(className, downloadProjectCallback) => (
-                                            <MenuItem
-                                                className={className}
-                                                onClick={this.getSaveToComputerHandler(downloadProjectCallback)}
-                                            >
-                                                <FormattedMessage
-                                                    defaultMessage="Save to your computer"
-                                                    description="Menu bar item for downloading a project to your computer" // eslint-disable-line max-len
-                                                    id="gui.menuBar.downloadToComputer"
-                                                />
-                                            </MenuItem>
+                                        <SB3Downloader>{(className, downloadProjectCallback, saveToLastFile) => (
+                                            <React.Fragment>
+                                                {window.showSaveFilePicker && this.props.isStandalone && (
+                                                    <MenuItem
+                                                        className={classNames(className, {
+                                                            [styles.disabled]: this.props.fileHandle === null
+                                                        })}
+                                                        onClick={this.getSaveToComputerHandler(saveToLastFile)}
+                                                    >
+                                                        <FormattedMessage
+                                                            defaultMessage="Save to original file"
+                                                            description="Menu bar item for save a project to original file" // eslint-disable-line max-len
+                                                            id="gui.menuBar.saveToOriginalFile"
+                                                        />
+                                                    </MenuItem>
+                                                )}
+                                                <MenuItem
+                                                    className={className}
+                                                    onClick={this.getSaveToComputerHandler(downloadProjectCallback)}
+                                                >
+                                                    <FormattedMessage
+                                                        defaultMessage="Save to your computer"
+                                                        description="Menu bar item for downloading a project to your computer" // eslint-disable-line max-len
+                                                        id="gui.menuBar.downloadToComputer"
+                                                    />
+                                                </MenuItem>
+                                            </React.Fragment>
                                         )}</SB3Downloader>
                                     </MenuSection>
                                 </MenuBarMenu>
@@ -632,27 +650,27 @@ class MenuBar extends React.Component {
                     </div>
                     */}
 
-<Divider className={classNames(styles.divider)} />
-                            {this.props.canEditTitle ? (
-                                <div className={classNames(styles.menuBarItem, styles.growable)}>
-                                    <MenuBarItemTooltip
-                                        enable
-                                        id="title-field"
-                                    >
-                                        <ProjectTitleInput
-                                            className={classNames(styles.titleFieldGrowable)}
-                                        />
-                                    </MenuBarItemTooltip>
-                                </div>
-                            ) : ((this.props.authorUsername && this.props.authorUsername !== this.props.username) ? (
-                                <AuthorInfo
-                                    className={styles.authorInfo}
-                                    imageUrl={this.props.authorThumbnailUrl}
-                                    projectTitle={this.props.projectTitle}
-                                    userId={this.props.authorId}
-                                    username={this.props.authorUsername}
+                    <Divider className={classNames(styles.divider)} />
+                    {this.props.canEditTitle ? (
+                        <div className={classNames(styles.menuBarItem, styles.growable)}>
+                            <MenuBarItemTooltip
+                                enable
+                                id="title-field"
+                            >
+                                <ProjectTitleInput
+                                    className={classNames(styles.titleFieldGrowable)}
                                 />
-                            ) : null)}
+                            </MenuBarItemTooltip>
+                        </div>
+                    ) : ((this.props.authorUsername && this.props.authorUsername !== this.props.username) ? (
+                        <AuthorInfo
+                            className={styles.authorInfo}
+                            imageUrl={this.props.authorThumbnailUrl}
+                            projectTitle={this.props.projectTitle}
+                            userId={this.props.authorId}
+                            username={this.props.authorUsername}
+                        />
+                    ) : null)}
 
                     {this.props.isStandalone ? null : (
                         <>
@@ -714,13 +732,11 @@ class MenuBar extends React.Component {
 
                 {/* show the proper UI in the account menu, given whether the user is
                 logged in, and whether a session is available to log in with */}
+                <div className={styles.menuBarItem}>
+                    <SaveStatus canSave={this.props.canSave} />
+                </div>
                 {this.props.isStandalone ? null : (
                     <div className={styles.accountInfoGroup}>
-                        <div className={styles.menuBarItem}>
-                            {this.props.canSave && (
-                                <SaveStatus />
-                            )}
-                        </div>
                         {this.props.sessionExists ? (
                             this.props.username ? (
                                 // ************ user is logged in ************
@@ -869,6 +885,7 @@ MenuBar.propTypes = {
     otherMenuOpen: PropTypes.bool,
     enableCommunity: PropTypes.bool,
     fileMenuOpen: PropTypes.bool,
+    fileHandle: PropTypes.func,
     intl: intlShape,
     isRtl: PropTypes.bool,
     isShared: PropTypes.bool,
@@ -915,6 +932,7 @@ MenuBar.propTypes = {
     onRequestCloseOther: PropTypes.func,
     onSeeCommunity: PropTypes.func,
     onShare: PropTypes.func,
+    onSetFileSystemHandle: PropTypes.func,
     // onToggleLoginOpen: PropTypes.func,
     onStartSelectingFileUpload: PropTypes.func,
     onToggleLoginOpen: PropTypes.func,
@@ -941,6 +959,7 @@ const mapStateToProps = (state, ownProps) => {
         aboutMenuOpen: aboutMenuOpen(state),
         accountMenuOpen: accountMenuOpen(state),
         fileMenuOpen: fileMenuOpen(state),
+        fileHandle: state.scratchGui.projectState.fileHandle,
         editMenuOpen: editMenuOpen(state),
         otherMenuOpen: otherMenuOpen(state),
         isRtl: state.locales.isRtl,
@@ -982,7 +1001,8 @@ const mapDispatchToProps = dispatch => ({
     onClickRemix: () => dispatch(remixProject()),
     onClickSave: () => dispatch(manualUpdateProject()),
     onClickSaveAsCopy: () => dispatch(saveProjectAsCopy()),
-    onSeeCommunity: () => dispatch(setPlayer(true))
+    onSeeCommunity: () => dispatch(setPlayer(true)),
+    onSetFileSystemHandle: fileHandle => dispatch(setFileSystemHandle(fileHandle))
 });
 
 export default compose(

--- a/src/components/menu-bar/save-status.jsx
+++ b/src/components/menu-bar/save-status.jsx
@@ -22,12 +22,13 @@ import styles from './save-status.css';
 // of the project state, rather than an event.
 const SaveStatus = ({
     alertsList,
+    canSave,
     projectChanged,
     onClickSave
 }) => (
     filterInlineAlerts(alertsList).length > 0 ? (
         <InlineMessages />
-    ) : projectChanged && (
+    ) : projectChanged && canSave && (
         <div
             className={styles.saveNow}
             onClick={onClickSave}
@@ -42,6 +43,7 @@ const SaveStatus = ({
 
 SaveStatus.propTypes = {
     alertsList: PropTypes.arrayOf(PropTypes.object),
+    canSave: PropTypes.bool,
     onClickSave: PropTypes.func,
     projectChanged: PropTypes.bool
 };

--- a/src/components/menu-bar/save-status.jsx
+++ b/src/components/menu-bar/save-status.jsx
@@ -1,7 +1,7 @@
 import {connect} from 'react-redux';
-import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {defineMessages, injectIntl, intlShape} from 'react-intl';
 
 import InlineMessages from '../../containers/inline-messages.jsx';
 
@@ -15,6 +15,23 @@ import {
 
 import styles from './save-status.css';
 
+
+const messages = defineMessages({
+    saveNow: {
+        // defaultMessage: 'Auto Save',
+        defaultMessage: 'Save Now',
+        description: 'Title bar link for saving now',
+        id: 'gui.menuBar.saveNowLink'
+    },
+    saveOriginalFile: {
+        // defaultMessage: 'Save Computer',
+        defaultMessage: 'Save to original file',
+        description: 'Title bar link for saving original file',
+        id: 'gui.menuBar.saveToOriginalFile'
+    }
+});
+
+
 // Wrapper for inline messages in the nav bar, which are all related to saving.
 // Show any inline messages if present, else show the "Save Now" button if the
 // project has changed.
@@ -22,28 +39,30 @@ import styles from './save-status.css';
 // of the project state, rather than an event.
 const SaveStatus = ({
     alertsList,
+    intl,
+    isStandalone,
     canSave,
+    fileHandle,
     projectChanged,
     onClickSave
 }) => (
     filterInlineAlerts(alertsList).length > 0 ? (
         <InlineMessages />
-    ) : projectChanged && canSave && (
+    ) : projectChanged && (canSave || (!!window.showSaveFilePicker && !!isStandalone && fileHandle !== null)) && (
         <div
             className={styles.saveNow}
             onClick={onClickSave}
         >
-            <FormattedMessage
-                defaultMessage="Save Now"
-                description="Title bar link for saving now"
-                id="gui.menuBar.saveNowLink"
-            />
+            {intl.formatMessage(canSave ? messages.saveNow : messages.saveOriginalFile)}
         </div>
     ));
 
 SaveStatus.propTypes = {
+    intl: intlShape.isRequired,
     alertsList: PropTypes.arrayOf(PropTypes.object),
+    isStandalone: PropTypes.bool,
     canSave: PropTypes.bool,
+    fileHandle: PropTypes.func,
     onClickSave: PropTypes.func,
     projectChanged: PropTypes.bool
 };
@@ -57,7 +76,7 @@ const mapDispatchToProps = dispatch => ({
     onClickSave: () => dispatch(manualUpdateProject())
 });
 
-export default connect(
+export default injectIntl(connect(
     mapStateToProps,
     mapDispatchToProps
-)(SaveStatus);
+)(SaveStatus));

--- a/src/components/settings-modal/autosave-settings.jsx
+++ b/src/components/settings-modal/autosave-settings.jsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import classNames from 'classnames';
+import Input from '../forms/input.jsx';
+import Box from '../box/box.jsx';
+import BufferedInputHOC from '../forms/buffered-input-hoc.jsx';
+import {defineMessages, injectIntl, intlShape} from 'react-intl';
+import {updateSetting, getSetting} from '../../reducers/settings';
+import styles from './layout-setting.css';
+
+
+const BufferedInput = BufferedInputHOC(Input);
+
+const messages = defineMessages({
+    label: {
+        defaultMessage: 'Auto Save',
+        description: 'Label of Handling Auto Save',
+        id: 'gui.settingsModal.autosave.label'
+    },
+    on: {
+        defaultMessage: 'Enabled',
+        description: 'Label of enabled',
+        id: 'gui.settingsModal.autosave.on'
+    },
+    off: {
+        defaultMessage: 'Disabled',
+        description: 'Label of disabled',
+        id: 'gui.settingsModal.autosave.off'
+    },
+    AutoSaveSecs: {
+        defaultMessage: 'Auto Save interval',
+        description: 'Label of Auto Save interval',
+        id: 'gui.settingsModal.autosave.autosaveinterval'
+    },
+    unSupport: {
+        defaultMessage: 'Your browser not support autosave :(',
+        description: 'Label of unsupport browser',
+        id: 'gui.settingsModal.autosave.unsupport'
+    }
+});
+
+const AutoSaveSetting = props => (
+    <React.Fragment>
+        <Box
+            justifyContent="space-between"
+            alignContent="center"
+            alignItems="center"
+            style={{display: 'flex'}}
+        >
+            <p
+                className={classNames(
+                    styles.text
+                )}
+            >
+                {props.intl.formatMessage(messages.label)}
+            </p>
+            <Box
+                alignContent="center"
+                alignItems="center"
+                style={{display: 'flex'}}
+            >
+                <span
+                    className={classNames(
+                        styles.switch,
+                        styles.switchLeft,
+                        props.autoSave === 'on' ? styles.active : null
+                    )}
+                    /* eslint-disable react/jsx-no-bind,no-alert */
+                    onClick={() => {
+                        if (!window.showSaveFilePicker) return alert(props.intl.formatMessage(messages.unSupport));
+                        props.onEnable();
+                    }}
+                /* eslint-enable react/jsx-no-bind,no-alert */
+                >
+                    <div>{props.intl.formatMessage(messages.on)}</div>
+                </span>
+                <span
+                    className={classNames(
+                        styles.switchRight,
+                        styles.switch,
+                        props.autoSave === 'off' ? styles.active : null
+                    )}
+                    onClick={props.onDisable}
+                >
+                    <div>{props.intl.formatMessage(messages.off)}</div>
+                </span>
+            </Box>
+        </Box>
+        <Box
+            justifyContent="space-between"
+            alignContent="center"
+            alignItems="center"
+            style={{display: 'flex'}}
+        >
+            <p
+                className={classNames(
+                    styles.text
+                )}
+            >
+                {props.intl.formatMessage(messages.AutoSaveSecs)}
+            </p>
+            <Box
+                alignContent="center"
+                alignItems="center"
+                style={{display: 'flex'}}
+            >
+                <BufferedInput
+                    tabIndex="1"
+                    type="number"
+                    min="10"
+                    max="360"
+                    disabled={props.autoSave === 'off'}
+                    value={props.autoSaveSecs}
+                    onSubmit={props.onSetAutoSaveSecs}
+                />
+            </Box>
+        </Box>
+    </React.Fragment>
+);
+
+AutoSaveSetting.propTypes = {
+    intl: intlShape.isRequired,
+    autoSaveSecs: PropTypes.number.isRequired,
+    autoSave: PropTypes.string.isRequired,
+    onEnable: PropTypes.func.isRequired,
+    onSetAutoSaveSecs: PropTypes.func.isRequired,
+    onDisable: PropTypes.func.isRequired
+};
+const mapStateToProps = state => ({
+    autoSave: getSetting(state, 'autosave'),
+    autoSaveSecs: getSetting(state, 'autoSaveSecs')
+});
+
+const mapDispatchToProps = dispatch => ({
+    onEnable: () => dispatch(updateSetting('autosave', 'on')),
+    onDisable: () => dispatch(updateSetting('autosave', 'off')),
+    onSetAutoSaveSecs: secs => dispatch(updateSetting('autoSaveSecs', secs))
+});
+
+export default injectIntl(connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(AutoSaveSetting));

--- a/src/components/settings-modal/compatibility-setting.jsx
+++ b/src/components/settings-modal/compatibility-setting.jsx
@@ -60,8 +60,13 @@ const CompatibilitySetting = props => (
                     props.compatibility === 'donotload' ? styles.active : null
                 )}
                 onClick={() => {
-                	props.onClickDoNotLoad();
-                	props.setDeserializeOption('donotload');
+                    try {
+                        props.setDeserializeOption('donotload');
+                        props.onClickDoNotLoad();
+                    } catch (e) {
+                        alert('Failed to change setting:' + e);
+                        console.error('Failed to change setting:', e);
+                    }
                 }}
             >
                 <div>{props.intl.formatMessage(messages.donotload)}</div>
@@ -73,8 +78,13 @@ const CompatibilitySetting = props => (
                     props.compatibility === 'replace' ? styles.active : null
                 )}
                 onClick={() => {
-                	props.onClickReplace();
-                	props.setDeserializeOption('replace');
+                    try {
+                        props.setDeserializeOption('replace');
+                        props.onClickReplace();
+                    } catch (e) {
+                        alert('Failed to change setting:' + e);
+                        console.error('Failed to change setting:', e);
+                    }
                 }}
             >
                 <div>{props.intl.formatMessage(messages.convert)}</div>

--- a/src/components/settings-modal/compression-setting.jsx
+++ b/src/components/settings-modal/compression-setting.jsx
@@ -47,8 +47,13 @@ const CompressionSetting = props => (
                 type="number"
                 value={props.compression}
                 onSubmit={value => {
-                	props.onChangeCompression(value);
-                	props.setCompression(value);
+                    try {
+                        props.setCompression(value);
+                        props.onChangeCompression(value);
+                    } catch (e) {
+                        alert('Failed to change setting:' + e);
+                        console.error('Failed to change setting:', e);
+                    }
                 }}
             />
         </Box>

--- a/src/components/settings-modal/settings-modal.jsx
+++ b/src/components/settings-modal/settings-modal.jsx
@@ -22,6 +22,7 @@ import DarkModeSetting from './darkmode-setting.jsx';
 import BlurSetting from './blur-setting.jsx'
 import CompatibilitySetting from './compatibility-setting.jsx';
 import CompressionSetting from './compression-setting.jsx';
+import AutoSaveSetting from './autosave-settings.jsx';
 
 const messages = defineMessages({
     title: {
@@ -111,6 +112,7 @@ const SettingsModal = ({
                 <CompatibilitySetting
                     setDeserializeOption={setDeserializeOption}
                 />
+                <AutoSaveSetting />
                 <CompressionSetting
                     setCompression={setCompression}
                 />

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -356,6 +356,7 @@ class Blocks extends React.Component {
         }
     }
     onWorkspaceUpdate (data) {
+        console.log(this.props.vm.editingTarget.id, data);
         // When we change sprites, update the toolbox to have the new sprite's blocks
         const toolboxXML = this.getToolboxXML();
         if (toolboxXML) {
@@ -368,9 +369,16 @@ class Blocks extends React.Component {
 
         // Remove and reattach the workspace listener (but allow flyout events)
         this.workspace.removeChangeListener(this.props.vm.blockListener);
-        const dom = this.ScratchBlocks.Xml.textToDom(data.xml);
         try {
-            this.ScratchBlocks.Xml.clearWorkspaceAndLoadFromXml(dom, this.workspace);
+            const id = this.props.vm.editingTarget.id;
+            if (this.workspace.hasCache(id)) {
+                this.workspace.switchToCache(id);
+            }
+            else {
+                const dom = this.ScratchBlocks.Xml.textToDom(data.xml);
+                this.ScratchBlocks.Xml.createWorkspaceCacheAndLoadFromXml(dom, this.workspace, id);
+                // this.ScratchBlocks.Xml.clearWorkspaceAndLoadFromXml(dom, this.workspace);
+            }
         } catch (error) {
             // The workspace is likely incomplete. What did update should be
             // functional.

--- a/src/containers/sb3-downloader.jsx
+++ b/src/containers/sb3-downloader.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {projectTitleInitialState} from '../reducers/project-title';
 import downloadBlob from '../lib/download-blob';
+import {notScratchDesktop} from '../lib/isScratchDesktop';
 import log from '../lib/log';
 import {showAlertWithTimeout} from '../reducers/alerts';
 import {setFileSystemHandle} from '../reducers/project-state';
@@ -34,7 +35,7 @@ class SB3Downloader extends React.Component {
         if (this.props.onSaveFinished) {
             this.props.onSaveFinished();
         }
-        if (window.showSaveFilePicker) {
+        if (window.showSaveFilePicker && notScratchDesktop()) {
             await this.saveFilePicker(this.props.projectFilename, content);
         } else {
             downloadBlob(this.props.projectFilename, content);

--- a/src/containers/sb3-downloader.jsx
+++ b/src/containers/sb3-downloader.jsx
@@ -7,6 +7,7 @@ import downloadBlob from '../lib/download-blob';
 import log from '../lib/log';
 import {showAlertWithTimeout} from '../reducers/alerts';
 import {setFileSystemHandle} from '../reducers/project-state';
+import {setProjectUnchanged} from '../reducers/project-changed';
 /**
  * Project saver component passes a downloadProject function to its child.
  * It expects this child to be a function with the signature
@@ -49,6 +50,7 @@ class SB3Downloader extends React.Component {
         await writable.write(content);
         await writable.close();
         this.props.onShowSaveSuccessAlert();
+        this.props.onSetProjectUnchanged();
     }
     async saveFilePicker (fileName, content) {
         try {
@@ -68,6 +70,7 @@ class SB3Downloader extends React.Component {
             await writable.write(content);
             this.props.onSetFileSystemHandle(fileHandle);
             await writable.close();
+            this.props.onSetProjectUnchanged();
             this.props.onShowSaveSuccessAlert();
         } catch (err) {
             log.error(err);
@@ -102,6 +105,7 @@ SB3Downloader.propTypes = {
     fileHandle: PropTypes.func,
     onSaveFinished: PropTypes.func,
     onSetFileSystemHandle: PropTypes.func,
+    onSetProjectUnchanged: PropTypes.func,
     onShowSavingAlert: PropTypes.func,
     onShowSaveSuccessAlert: PropTypes.func,
     projectFilename: PropTypes.string,
@@ -118,6 +122,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
+    onSetProjectUnchanged: () => dispatch(setProjectUnchanged()),
     onSetFileSystemHandle: fileHandle => dispatch(setFileSystemHandle(fileHandle)),
     onShowSaveSuccessAlert: () => showAlertWithTimeout(dispatch, 'saveSuccess'),
     onShowSavingAlert: () => showAlertWithTimeout(dispatch, 'saving')

--- a/src/containers/sb3-downloader.jsx
+++ b/src/containers/sb3-downloader.jsx
@@ -66,7 +66,6 @@ class SB3Downloader extends React.Component {
             this.props.onShowSavingAlert();
             const writable = await fileHandle.createWritable();
             await writable.write(content);
-            this.props.onShowSaveSuccessAlert();
             this.props.onSetFileSystemHandle(fileHandle);
             await writable.close();
             this.props.onShowSaveSuccessAlert();

--- a/src/containers/sb3-downloader.jsx
+++ b/src/containers/sb3-downloader.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {projectTitleInitialState} from '../reducers/project-title';
 import downloadBlob from '../lib/download-blob';
-import {notScratchDesktop} from '../lib/isScratchDesktop';
 import log from '../lib/log';
 import {showAlertWithTimeout} from '../reducers/alerts';
 import {setFileSystemHandle} from '../reducers/project-state';
@@ -35,7 +34,7 @@ class SB3Downloader extends React.Component {
         if (this.props.onSaveFinished) {
             this.props.onSaveFinished();
         }
-        if (window.showSaveFilePicker && notScratchDesktop()) {
+        if (window.showSaveFilePicker) {
             await this.saveFilePicker(this.props.projectFilename, content);
         } else {
             downloadBlob(this.props.projectFilename, content);

--- a/src/lib/sb-file-uploader-hoc.jsx
+++ b/src/lib/sb-file-uploader-hoc.jsx
@@ -76,29 +76,28 @@ const SBFileUploaderHOC = function (WrappedComponent) {
             this.fileReader = new FileReader();
             this.fileReader.onload = this.onload;
             if (window.showOpenFilePicker) {
-                window.showOpenFilePicker({
-                    types: [
-                        {
-                            description: 'Scratch File',
-                            accept: {
-                                'application/x.scratch.sb3': ['.sb', '.sb2', '.sb3', '.cc3']
-                            }
-                        }
-                    ],
-                    multiple: false
-                }).then(([handle]) => {
-                    handle.getFile()
-                        .then(file => {
-                            this.handleChange({
-                                target: {
-                                    files: [file]
+                (async () => {
+                    const [handle] = await window.showOpenFilePicker({
+                        types: [
+                            {
+                                description: 'Scratch File',
+                                accept: {
+                                    'application/x.scratch.sb3': ['.sb', '.sb2', '.sb3', '.cc3']
                                 }
-                            });
-                            if (file.name.endsWith('.sb3')) {
-                                this.props.onSetFileSystemHandle(handle);
                             }
-                        });
-                });
+                        ],
+                        multiple: false
+                    });
+                    const file = await handle.getFile();
+                    this.handleChange({
+                        target: {
+                            files: [file]
+                        }
+                    });
+                    if (file.name.endsWith('.sb3')) {
+                        this.props.onSetFileSystemHandle(handle);
+                    }
+                })();
             } else {
                 // create <input> element and add it to DOM
                 this.inputElement = document.createElement('input');
@@ -186,6 +185,7 @@ const SBFileUploaderHOC = function (WrappedComponent) {
                     })
                     .catch(error => {
                         log.warn(error);
+                        this.props.onSetFileSystemHandle(null);
                         alert(this.props.intl.formatMessage(messages.loadError)); // eslint-disable-line no-alert
                     })
                     .then(() => {

--- a/src/lib/sb-file-uploader-hoc.jsx
+++ b/src/lib/sb-file-uploader-hoc.jsx
@@ -22,6 +22,7 @@ import {
 import {
     closeFileMenu
 } from '../reducers/menus';
+import { getSetting } from '../reducers/settings';
 
 const messages = defineMessages({
     loadError: {
@@ -97,6 +98,10 @@ const SBFileUploaderHOC = function (WrappedComponent) {
                     if (file.name.endsWith('.sb3')) {
                         this.props.onSetFileSystemHandle(handle);
                     }
+                    if (this.props.enableAutoSave && await handle.queryPermission({mode: 'readwrite'}) === 'prompt') {
+                        await handle.requestPermission({mode: 'readwrite'});
+                    }
+
                 })();
             } else {
                 // create <input> element and add it to DOM
@@ -238,6 +243,7 @@ const SBFileUploaderHOC = function (WrappedComponent) {
     SBFileUploaderComponent.propTypes = {
         canSave: PropTypes.bool,
         cancelFileUpload: PropTypes.func,
+        enableAutoSave: PropTypes.bool,
         closeFileMenu: PropTypes.func,
         intl: intlShape.isRequired,
         isLoadingUpload: PropTypes.bool,
@@ -257,7 +263,9 @@ const SBFileUploaderHOC = function (WrappedComponent) {
     const mapStateToProps = (state, ownProps) => {
         const loadingState = state.scratchGui.projectState.loadingState;
         const user = state.session && state.session.session && state.session.session.user;
+        const enableAutoSave = getSetting(state, 'autosave') === 'on';
         return {
+            enableAutoSave: enableAutoSave,
             isLoadingUpload: getIsLoadingUpload(loadingState),
             isShowingWithoutId: getIsShowingWithoutId(loadingState),
             loadingState: loadingState,

--- a/src/lib/supported-browser.js
+++ b/src/lib/supported-browser.js
@@ -1,10 +1,10 @@
 import bowser from 'bowser';
 
 const minVersions = {
-    chrome: '63',
-    msedge: '15',
-    firefox: '57',
-    safari: '11'
+    chrome: '72',
+    msedge: '19',
+    firefox: '70',
+    safari: '12'
 };
 
 /**

--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -34,9 +34,15 @@ const vmManagerHOC = function (WrappedComponent) {
                 this.audioEngine = new AudioEngine();
                 this.props.vm.attachAudioEngine(this.audioEngine);
                 this.props.vm.setCompatibilityMode(true);
-                this.props.vm.runtime.setFramerate(parseInt(this.props.fps));
-                this.props.vm.setCompressionLevel(parseInt(this.props.compression));
-                this.props.vm.setDeserializeOption(this.props.compatibility);
+                
+                //初始化设置
+                try {
+                    this.props.vm.runtime.setFramerate(parseInt(this.props.fps));
+                    this.props.vm.setCompressionLevel(parseInt(this.props.compression));
+                    this.props.vm.setDeserializeOption(this.props.compatibility);
+                } catch (e) {
+                    console.log('Failed to initialize settings:', e);
+                }
                 this.props.vm.initialized = true;
                 this.props.vm.setLocale(this.props.locale, this.props.messages);
             }

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -1,9 +1,3 @@
-// Polyfills
-import 'es6-object-assign/auto';
-import 'core-js/fn/array/includes';
-import 'core-js/fn/promise/finally';
-import 'intl'; // For Safari 9
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -22,6 +22,7 @@ const START_MANUAL_UPDATING = 'clipcc-gui/project-state/START_MANUAL_UPDATING';
 const START_REMIXING = 'clipcc-gui/project-state/START_REMIXING';
 const START_UPDATING_BEFORE_CREATING_COPY = 'clipcc-gui/project-state/START_UPDATING_BEFORE_CREATING_COPY';
 const START_UPDATING_BEFORE_CREATING_NEW = 'clipcc-gui/project-state/START_UPDATING_BEFORE_CREATING_NEW';
+const SET_FILESYSTEM_HANDLE = 'clipcc-gui/project-state/SET_FILESYSTEM_HANDLE';
 
 const defaultProjectId = '0'; // hardcoded id of default project
 const externalProjectId = '-1'; // hardcoded id of external project (Passed by file)
@@ -109,12 +110,12 @@ const initialState = {
     error: null,
     projectData: null,
     projectId: null,
+    fileHandle: null,
     loadingState: LoadingState.NOT_LOADED
 };
 
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
-
     switch (action.type) {
     case DONE_CREATING_NEW:
         // We need to set project id since we just created new project on the server.
@@ -371,6 +372,10 @@ const reducer = function (state, action) {
             });
         }
         return state;
+    case SET_FILESYSTEM_HANDLE:
+        return Object.assign({}, state, {
+            fileHandle: action.fileHandle
+        });
     default:
         return state;
     }
@@ -511,6 +516,11 @@ const remixProject = () => ({
     type: START_REMIXING
 });
 
+const setFileSystemHandle = fileHandle => ({
+    type: SET_FILESYSTEM_HANDLE,
+    fileHandle: fileHandle
+});
+
 export {
     reducer as default,
     initialState as projectStateInitialState,
@@ -544,5 +554,6 @@ export {
     requestNewProject,
     requestProjectUpload,
     saveProjectAsCopy,
-    setProjectId
+    setProjectId,
+    setFileSystemHandle
 };

--- a/src/reducers/project-state.js
+++ b/src/reducers/project-state.js
@@ -267,7 +267,8 @@ const reducer = function (state, action) {
         }
         return state;
     case START_AUTO_UPDATING:
-        if (state.loadingState === LoadingState.SHOWING_WITH_ID) {
+        if (state.loadingState === LoadingState.SHOWING_WITH_ID ||
+            state.loadingState === LoadingState.SHOWING_WITHOUT_ID) {
             return Object.assign({}, state, {
                 loadingState: LoadingState.AUTO_UPDATING
             });
@@ -303,7 +304,8 @@ const reducer = function (state, action) {
         }
         return state;
     case START_MANUAL_UPDATING:
-        if (state.loadingState === LoadingState.SHOWING_WITH_ID) {
+        if ((state.loadingState === LoadingState.SHOWING_WITH_ID ||
+            state.loadingState === LoadingState.SHOWING_WITHOUT_ID)) {
             return Object.assign({}, state, {
                 loadingState: LoadingState.MANUAL_UPDATING
             });

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -2,9 +2,11 @@ const SETTING_UPDATE = 'clipcc-gui/settings/SETTING_UPDATE';
 
 const initialState = {
     layoutStyle: 'scratch3',
+    autoSaveSecs: 120,
     darkMode: 'system',
     fps: 60,
     blur: 'on',
+    autosave: 'off',
     compatibility: 'donotload',
     compression: 6
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,12 +58,12 @@ const base = {
                 plugins: [
                     '@babel/plugin-syntax-dynamic-import',
                     '@babel/plugin-transform-async-to-generator',
-                    '@babel/plugin-proposal-object-rest-spread',
+                    // '@babel/plugin-proposal-object-rest-spread',
                     ['react-intl', {
                         messagesDir: './translations/messages/'
                     }]],
                 presets: [
-                    ['@babel/preset-env', {"targets": {"browsers": ["last 3 versions", "Safari >= 8", "iOS >= 8"]}}], 
+                    ['@babel/preset-env'],
                     '@babel/preset-react'
                 ]
             }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,7 +58,7 @@ const base = {
                 plugins: [
                     '@babel/plugin-syntax-dynamic-import',
                     '@babel/plugin-transform-async-to-generator',
-                    // '@babel/plugin-proposal-object-rest-spread',
+                    '@babel/plugin-proposal-object-rest-spread',
                     ['react-intl', {
                         messagesDir: './translations/messages/'
                     }]],


### PR DESCRIPTION
本分支让ClipCC拥有自动保存及直接保存到本地的能力，桌面端也能受益于这些更改 （使用[filesystem-access-api](//developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API)）    



![文件系统api](https://user-images.githubusercontent.com/46376077/145592789-e7e46dd7-87a5-4adb-9dfe-bd49ffabe5a0.gif)
>文件系统API，可以直接保存到已选择的文件而无需选择路径


![自动保存](https://user-images.githubusercontent.com/46376077/145592654-59195e03-c384-4d9e-85b8-c9b504b623b3.gif)
>自动保存功能

### 具体更改
- [x] 实现了文件API的打开/保存
- [x] 自动保存功能，用户可以选择是否打开（默认关闭）
- [x] 自动保存间隔 默认120秒
- [x] 删除了Ployfill 以可以在ClipCC内使用Async语法糖 

