### PR TITLE
Rename Dark Mode options to be less confusing to the user

### DIFF
--- a/src/components/settings-modal/settings-modal.jsx
+++ b/src/components/settings-modal/settings-modal.jsx
@@ -63,12 +63,12 @@ const messages = defineMessages({
         id: 'gui.settingsModal.layout.scratch3'
     },
     darkmode: {
-        defaultMessage: 'Dark Mode',
+        defaultMessage: 'Theme',
         description: 'Label of ClipCC dark mode',
         id: 'gui.settingsModal.darkmode.label'
     },
     darkmodeSystem: {
-        defaultMessage: 'System',
+        defaultMessage: 'System Default',
         description: 'Label of system',
         id: 'gui.settingsModal.darkmode.system'
     },


### PR DESCRIPTION
It was previously a 'Dark Mode' option, but considering the options were 'System', 'Light', 'Dark' it would make sense to make it display something like 'Theme'. I also changed the 'System' option to 'System UI' as that would make more sense. This would also make room for custom, or built in themes, a selection in fact.

_**NOTICE: PLEASE REVIEW ALL CHANGES OF THIS PR, IT IS RECOMMENDED TO TEST THIS PR BEFORE MERGING.**_