### PR TITLE
复制积木到剪贴板 / 从剪贴板粘贴积木

### DIFF
--- a/src/lib/backpack/block-to-image.js
+++ b/src/lib/backpack/block-to-image.js
@@ -27,8 +27,8 @@ export default function (blockId) {
             // Needs to be on the DOM to get CSS properties and correct sizing
             document.body.appendChild(svg);
 
-            const padding = 10;
-            const extraHatPadding = 16;
+            const padding = 15;
+            const extraHatPadding = 28;
             const topPadding = padding + (blockSvg.getAttribute('data-shapes') === 'hat' ? extraHatPadding : 0);
             const leftPadding = padding;
             blockSvg.setAttribute('transform', `translate(${leftPadding} ${topPadding})`);

--- a/src/lib/backpack/jpeg-thumbnail.js
+++ b/src/lib/backpack/jpeg-thumbnail.js
@@ -14,8 +14,8 @@ const jpegThumbnail = (dataUrl, needBlob) => new Promise((resolve, reject) => {
             ctx.fillRect(0, 0, canvas.width, canvas.height);
         } else {
             if (!!needBlob) {
-                canvas.width = image.width;
-                canvas.height = image.height;
+                canvas.width = image.width * 2;
+                canvas.height = image.height * 2;
             } else {
                 if (image.height > image.width) {
                     canvas.height = maxDimension;

--- a/src/lib/backpack/jpeg-thumbnail.js
+++ b/src/lib/backpack/jpeg-thumbnail.js
@@ -1,4 +1,4 @@
-const jpegThumbnail = dataUrl => new Promise((resolve, reject) => {
+const jpegThumbnail = (dataUrl, needBlob) => new Promise((resolve, reject) => {
     const image = new Image();
     image.onload = () => {
         const canvas = document.createElement('canvas');
@@ -24,7 +24,8 @@ const jpegThumbnail = dataUrl => new Promise((resolve, reject) => {
             ctx.fillRect(0, 0, canvas.width, canvas.height);
             ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
         }
-        resolve(canvas.toDataURL('image/jpeg', 0.92 /* quality */)); // Default quality is 0.92
+        if (!!needBlob) resolve(canvas.toBlob());
+        else resolve(canvas.toDataURL('image/jpeg', 0.92 /* quality */)); // Default quality is 0.92
     };
     image.onerror = err => {
         reject(err);

--- a/src/lib/backpack/jpeg-thumbnail.js
+++ b/src/lib/backpack/jpeg-thumbnail.js
@@ -24,7 +24,11 @@ const jpegThumbnail = (dataUrl, needBlob) => new Promise((resolve, reject) => {
             ctx.fillRect(0, 0, canvas.width, canvas.height);
             ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
         }
-        if (!!needBlob) resolve(canvas.toBlob());
+        if (!!needBlob) {
+            canvas.toBlob(blob => {
+                resolve(blob)
+            }, 'image/jpg');
+        }
         else resolve(canvas.toDataURL('image/jpeg', 0.92 /* quality */)); // Default quality is 0.92
     };
     image.onerror = err => {

--- a/src/lib/backpack/jpeg-thumbnail.js
+++ b/src/lib/backpack/jpeg-thumbnail.js
@@ -4,7 +4,7 @@ const jpegThumbnail = (dataUrl, needBlob) => new Promise((resolve, reject) => {
         const canvas = document.createElement('canvas');
         const ctx = canvas.getContext('2d');
 
-        const maxDimension = needBlob? 1024 : 96; // 3x the maximum displayed size of 32px
+        const maxDimension = 96; // 3x the maximum displayed size of 32px
 
         if (image.height < 1 || image.width < 1) {
             canvas.width = canvas.height = maxDimension;
@@ -13,12 +13,17 @@ const jpegThumbnail = (dataUrl, needBlob) => new Promise((resolve, reject) => {
             ctx.fillStyle = 'white'; // Create white background, since jpeg doesn't have transparency
             ctx.fillRect(0, 0, canvas.width, canvas.height);
         } else {
-            if (image.height > image.width) {
-                canvas.height = maxDimension;
-                canvas.width = (maxDimension / image.height) * image.width;
+            if (!!needBlob) {
+                canvas.width = image.width;
+                canvas.height = image.height;
             } else {
-                canvas.width = maxDimension;
-                canvas.height = (maxDimension / image.width) * image.height;
+                if (image.height > image.width) {
+                    canvas.height = maxDimension;
+                    canvas.width = (maxDimension / image.height) * image.width;
+                } else {
+                    canvas.width = maxDimension;
+                    canvas.height = (maxDimension / image.width) * image.height;
+                }
             }
             ctx.fillStyle = 'white';
             ctx.fillRect(0, 0, canvas.width, canvas.height);

--- a/src/lib/backpack/jpeg-thumbnail.js
+++ b/src/lib/backpack/jpeg-thumbnail.js
@@ -4,7 +4,7 @@ const jpegThumbnail = (dataUrl, needBlob) => new Promise((resolve, reject) => {
         const canvas = document.createElement('canvas');
         const ctx = canvas.getContext('2d');
 
-        const maxDimension = 96; // 3x the maximum displayed size of 32px
+        const maxDimension = needBlob? 1024 : 96; // 3x the maximum displayed size of 32px
 
         if (image.height < 1 || image.width < 1) {
             canvas.width = canvas.height = maxDimension;

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -1,4 +1,19 @@
 import lazyClipCCBlock from './lazy-blocks';
+import blockToImage from './block-to-image';
+import jpegThumbnail from './jpeg-thumbnail';
+
+function dataURItoBlob (dataURI) {
+  const byteString = atob(dataURI);
+  const mimeString = 'image/jpeg'
+
+  const ab = new ArrayBuffer(byteString.length);
+  const ia = new Uint8Array(ab);
+
+  for (let i = 0; i < byteString.length; i++) {
+      ia[i] = byteString.charCodeAt(i);
+  }
+  return new Blob([ab], {type: mimeString});
+}
 
 /**
  * Connect scratch blocks with the vm
@@ -362,6 +377,19 @@ export default function (vm) {
                 callback(xml.documentElement);
             });
     };
+    
+    ScratchBlocks.scratchBlocksUtils.externalCopyImageCallback = function(blockId) {
+        return blockToImage(blockId)
+            .then(jpegThumbnail)
+            .then(thumbnail => {
+                const blob = dataURItoBlob(thumbnail);
+                const clipboardData = new ClipboardItem({
+                    [blob.type]: blob,
+                });
+                
+                navigator.clipboard.write([clipboardData]);
+            });
+    }
 
     // Blocks wants to know if 3D CSS transforms are supported. The cross
     // section of browsers Scratch supports and browsers that support 3D CSS

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -343,6 +343,14 @@ export default function (vm) {
     ScratchBlocks.scratchBlocksUtils.compareStrings = function (str1, str2) {
         return collator.compare(str1, str2);
     };
+    
+    ScratchBlocks.scratchBlocksUtils.externalCopyCallback = function (block, event) {
+        console.log('copy', block, event);
+    };
+    
+    ScratchBlocks.scratchBlocksUtils.externalPasteCallback = function (block, event) {
+        console.log('paste', block, event);
+    };
 
     // Blocks wants to know if 3D CSS transforms are supported. The cross
     // section of browsers Scratch supports and browsers that support 3D CSS

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -1,6 +1,6 @@
 import lazyClipCCBlock from './lazy-blocks';
-import blockToImage from './block-to-image';
-import jpegThumbnail from './jpeg-thumbnail';
+import blockToImage from './backpack/block-to-image';
+import jpegThumbnail from './backpack/jpeg-thumbnail';
 
 function dataURItoBlob (dataURI) {
   const byteString = atob(dataURI);

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -359,6 +359,7 @@ export default function (vm) {
                 }
                 
                 const xmlString = JSON.parse(text)[1];
+                if (xmlString.trim() === null) return;
                 const parser = new DOMParser();
                 const xml = parser.parseFromString(xmlString, "text/xml");
                 callback(xml.documentElement);

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -346,13 +346,23 @@ export default function (vm) {
     
     ScratchBlocks.scratchBlocksUtils.externalCopyCallback = function (xml) {
         console.log('copy', xml);
-        const blockObjects = adapter({xml});
-        const steveScratchCopiedBlock = JSON.stringify(['SSCB3', blockObjects]);
+        const steveScratchCopiedBlock = JSON.stringify(['SSCB3', (new XMLSerializer()).serializeToString(xml)]);
         navigator.clipboard.writeText(steveScratchCopiedBlock);
     };
     
     ScratchBlocks.scratchBlocksUtils.externalPasteCallback = function (block) {
         console.log('paste', block);
+        navigator.clipboard.readText()
+            .then(text => {
+                if (!text.trim().startsWith('["SSCB3"')) {
+                    console.log(`It's not a legal SSCB3 fragment.`);
+                    return;
+                }
+                
+                const xmlString = JSON.parse(text)[1];
+                const parser = new DOMParser();
+                return parser.parseFromString(xmlString, "text/xml");
+            });
     };
 
     // Blocks wants to know if 3D CSS transforms are supported. The cross

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -350,8 +350,7 @@ export default function (vm) {
         navigator.clipboard.writeText(steveScratchCopiedBlock);
     };
     
-    ScratchBlocks.scratchBlocksUtils.externalPasteCallback = function (block) {
-        console.log('paste', block);
+    ScratchBlocks.scratchBlocksUtils.externalPasteCallback = function () {
         navigator.clipboard.readText()
             .then(text => {
                 if (!text.trim().startsWith('["SSCB3"')) {

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -361,7 +361,9 @@ export default function (vm) {
                 
                 const xmlString = JSON.parse(text)[1];
                 const parser = new DOMParser();
-                return parser.parseFromString(xmlString, "text/xml");
+                const xml = parser.parseFromString(xmlString, "text/xml");
+                console.log(xml);
+                return xml;
             });
     };
 

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -1,5 +1,4 @@
 import lazyClipCCBlock from './lazy-blocks';
-import adapter from 'clipcc-vm/src/engine/adapter';
 
 /**
  * Connect scratch blocks with the vm

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -361,8 +361,8 @@ export default function (vm) {
                 const xmlString = JSON.parse(text)[1];
                 const parser = new DOMParser();
                 const xml = parser.parseFromString(xmlString, "text/xml");
-                console.log(xml);
-                callback(xml);
+                console.log(xml.documentElement);
+                callback(xml.documentElement);
             });
     };
 

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -350,7 +350,7 @@ export default function (vm) {
         navigator.clipboard.writeText(steveScratchCopiedBlock);
     };
     
-    ScratchBlocks.scratchBlocksUtils.externalPasteCallback = function () {
+    ScratchBlocks.scratchBlocksUtils.externalPasteCallback = function (callback) {
         navigator.clipboard.readText()
             .then(text => {
                 if (!text.trim().startsWith('["SSCB3"')) {
@@ -362,7 +362,7 @@ export default function (vm) {
                 const parser = new DOMParser();
                 const xml = parser.parseFromString(xmlString, "text/xml");
                 console.log(xml);
-                return xml;
+                callback(xml);
             });
     };
 

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -1,5 +1,5 @@
 import lazyClipCCBlock from './lazy-blocks';
-
+import adapter from 'clipcc-vm/src/engine/adapter';
 
 /**
  * Connect scratch blocks with the vm
@@ -344,12 +344,15 @@ export default function (vm) {
         return collator.compare(str1, str2);
     };
     
-    ScratchBlocks.scratchBlocksUtils.externalCopyCallback = function (block, event) {
-        console.log('copy', block, event);
+    ScratchBlocks.scratchBlocksUtils.externalCopyCallback = function (xml) {
+        console.log('copy', xml);
+        const blockObjects = adapter(xml);
+        const steveScratchCopiedBlock = JSON.stringify(blockObjects);
+        navigator.clipboard.writeText(steveScratchCopiedBlock);
     };
     
-    ScratchBlocks.scratchBlocksUtils.externalPasteCallback = function (block, event) {
-        console.log('paste', block, event);
+    ScratchBlocks.scratchBlocksUtils.externalPasteCallback = function (block) {
+        console.log('paste', block);
     };
 
     // Blocks wants to know if 3D CSS transforms are supported. The cross

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -345,7 +345,6 @@ export default function (vm) {
     };
     
     ScratchBlocks.scratchBlocksUtils.externalCopyCallback = function (xml) {
-        console.log('copy', xml);
         const steveScratchCopiedBlock = JSON.stringify(['SSCB3', (new XMLSerializer()).serializeToString(xml)]);
         navigator.clipboard.writeText(steveScratchCopiedBlock);
     };
@@ -354,14 +353,13 @@ export default function (vm) {
         navigator.clipboard.readText()
             .then(text => {
                 if (!text.trim().startsWith('["SSCB3"')) {
-                    console.log(`It's not a legal SSCB3 fragment.`);
+                    console.warn(`It's not a legal SSCB3 fragment.`);
                     return;
                 }
                 
                 const xmlString = JSON.parse(text)[1];
                 const parser = new DOMParser();
                 const xml = parser.parseFromString(xmlString, "text/xml");
-                console.log(xml.documentElement);
                 callback(xml.documentElement);
             });
     };

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -2,19 +2,6 @@ import lazyClipCCBlock from './lazy-blocks';
 import blockToImage from './backpack/block-to-image';
 import jpegThumbnail from './backpack/jpeg-thumbnail';
 
-function dataURItoBlob (dataURI) {
-  const byteString = atob(dataURI);
-  const mimeString = 'image/jpeg'
-
-  const ab = new ArrayBuffer(byteString.length);
-  const ia = new Uint8Array(ab);
-
-  for (let i = 0; i < byteString.length; i++) {
-      ia[i] = byteString.charCodeAt(i);
-  }
-  return new Blob([ab], {type: mimeString});
-}
-
 /**
  * Connect scratch blocks with the vm
  * @param {VirtualMachine} vm - The scratch vm
@@ -380,11 +367,12 @@ export default function (vm) {
     
     ScratchBlocks.scratchBlocksUtils.externalCopyImageCallback = function(blockId) {
         return blockToImage(blockId)
-            .then(jpegThumbnail)
+            .then(dataUrl => {
+                return jpegThumbnail(dataUrl, true);
+            })
             .then(thumbnail => {
-                const blob = dataURItoBlob(thumbnail);
                 const clipboardData = new ClipboardItem({
-                    [blob.type]: blob,
+                    [thumbnail.type]: thumbnail,
                 });
                 
                 navigator.clipboard.write([clipboardData]);

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -346,8 +346,8 @@ export default function (vm) {
     
     ScratchBlocks.scratchBlocksUtils.externalCopyCallback = function (xml) {
         console.log('copy', xml);
-        const blockObjects = adapter(xml);
-        const steveScratchCopiedBlock = JSON.stringify(blockObjects);
+        const blockObjects = adapter({xml});
+        const steveScratchCopiedBlock = JSON.stringify(['SSCB3', blockObjects]);
         navigator.clipboard.writeText(steveScratchCopiedBlock);
     };
     


### PR DESCRIPTION
### https://github.com/Clipteam/clipcc-block/pull/25 required
## ✨ 简介 - Overview
本 Pull request 为 ClipCC 添加了复制积木到剪贴版与从剪贴板粘贴积木的支持。
![Screenshot_20220819-095852_Kiwi_Browser](https://user-images.githubusercontent.com/59327348/185532478-c7cf1e61-88ab-4826-a314-59db4d11eb72.png)

## 🤔 修改原因 - Reason
1. 方便积木的跨作品分享(通过分享文本的方式直接交换脚本)
2. 方便对积木进行快速修改(通过修改 xml 的方式实现一些原版需要修改 json 才能实现的功能)
## 🎯 目标 - Todo
- [x] 完成复制
- [x] 完成粘贴
- [x] 自动创建变量
- [x] 自动创建列表