### PR TITLE
拯救世人的眼睛（暗色模式空白區域填黑）

### DIFF
--- a/src/components/gui/gui.css
+++ b/src/components/gui/gui.css
@@ -15,6 +15,10 @@
     background-color: $ui-primary-dark;
 }
 
+[theme='dark'] * {
+background-color: black;
+}
+
 .body-wrapper * {
     box-sizing: border-box;
 }


### PR DESCRIPTION
手機版介面畫面沒有填滿又是暗色模式時底下會出現超大片白色。比起主題的暗色用黑色比較能和網站主題區分開來